### PR TITLE
refactor: use othent2.0 in OthentStrategy class

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arweave-wallet-kit-beta/othent-strategy",
-  "version": "0.0.1-beta.6",
+  "version": "0.0.1-beta.7",
   "description": "Othent strategy for the Arweave Wallet Kit",
   "repository": "https://github.com/labscommunity/wallet-kit-othent",
   "author": "Marton Lederer <marton@lederer.hu>",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@arweave-wallet-kit/core": ">= 0.0.1-beta.1 < 2"
   },
   "dependencies": {
-    "@othent/kms": "^1.0.6",
+    "@othent/kms": "^1.0.7",
     "jwt-decode": "^4.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     }
   },
   "devDependencies": {
-    "@arweave-wallet-kit/core": "^0.0.1-beta.1",
+    "@arweave-wallet-kit/core": "^0.0.1-beta.5",
     "@types/node": "^20.4.2",
     "arweave": "^1.12.2",
     "othent": "^1.0.645",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@arweave-wallet-kit/othent-strategy",
-  "version": "0.0.1-beta.4",
+  "name": "@arweave-wallet-kit-beta/othent-strategy",
+  "version": "0.0.1-beta.5",
   "description": "Othent strategy for the Arweave Wallet Kit",
   "repository": "https://github.com/labscommunity/wallet-kit-othent",
   "author": "Marton Lederer <marton@lederer.hu>",
@@ -41,5 +41,9 @@
   "peerDependencies": {
     "@arweave-wallet-kit/core": ">= 0.0.1-beta.1 < 2",
     "othent": ">= 1.0.645 < 2"
+  },
+  "dependencies": {
+    "@othent/kms": "^1.0.5",
+    "jwt-decode": "^4.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arweave-wallet-kit-beta/othent-strategy",
-  "version": "0.0.1-beta.5",
+  "version": "0.0.1-beta.6",
   "description": "Othent strategy for the Arweave Wallet Kit",
   "repository": "https://github.com/labscommunity/wallet-kit-othent",
   "author": "Marton Lederer <marton@lederer.hu>",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@arweave-wallet-kit/core": ">= 0.0.1-beta.1 < 2"
   },
   "dependencies": {
-    "@othent/kms": "^1.0.5",
+    "@othent/kms": "^1.0.6",
     "jwt-decode": "^4.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@arweave-wallet-kit-beta/othent-strategy",
+  "name": "@arweave-wallet-kit/othent-strategy",
   "version": "0.0.1-beta.5",
   "description": "Othent strategy for the Arweave Wallet Kit",
   "repository": "https://github.com/labscommunity/wallet-kit-othent",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arweave-wallet-kit-beta/othent-strategy",
-  "version": "0.0.1-beta.7",
+  "version": "0.0.1-beta.5",
   "description": "Othent strategy for the Arweave Wallet Kit",
   "repository": "https://github.com/labscommunity/wallet-kit-othent",
   "author": "Marton Lederer <marton@lederer.hu>",

--- a/package.json
+++ b/package.json
@@ -39,8 +39,7 @@
     "vite-plugin-dts": "^3.2.0"
   },
   "peerDependencies": {
-    "@arweave-wallet-kit/core": ">= 0.0.1-beta.1 < 2",
-    "othent": ">= 1.0.645 < 2"
+    "@arweave-wallet-kit/core": ">= 0.0.1-beta.1 < 2"
   },
   "dependencies": {
     "@othent/kms": "^1.0.5",

--- a/src/OthentStrategy.ts
+++ b/src/OthentStrategy.ts
@@ -4,7 +4,7 @@ import { Strategy } from "@arweave-wallet-kit/core/strategy";
 import type Transaction from "arweave/web/lib/transaction";
 import * as othent from "@othent/kms";
 
-import { userDetails } from "./utils";
+import { deleteStoredToken, userDetails } from "./utils";
 import { ConnectResult } from "./types";
 
 export default class OthentStrategy implements Strategy {
@@ -54,6 +54,7 @@ export default class OthentStrategy implements Strategy {
 
   public async disconnect() {
     await othent.disconnect();
+    deleteStoredToken();
 
     for (const listener of this.#addressListeners) {
       listener(undefined as any);

--- a/src/OthentStrategy.ts
+++ b/src/OthentStrategy.ts
@@ -67,8 +67,8 @@ export default class OthentStrategy implements Strategy {
     return b64UrlToBuffer(response);
   }
 
-  public async dispatch(transaction: Transaction): Promise<DispatchResult> {
-    return "" as any;
+  public async dispatch(transaction: Transaction): Promise<{ id: string }> {
+    return othent.dispatch(transaction);
   }
 
   public async encrypt(data: Uint8Array): Promise<Uint8Array> {

--- a/src/OthentStrategy.ts
+++ b/src/OthentStrategy.ts
@@ -2,21 +2,10 @@ import type { SignatureOptions } from "arweave/node/lib/crypto/crypto-interface"
 import type { DispatchResult, GatewayConfig, PermissionType } from "arconnect";
 import { Strategy } from "@arweave-wallet-kit/core/strategy";
 import type Transaction from "arweave/web/lib/transaction";
-import type { AppInfo } from "arweave-wallet-connector";
-import { decodeTags } from "./utils";
-import {
-  Othent,
-  queryWalletAddressTxnsProps,
-  readCustomContractProps,
-  SendTransactionArweaveProps,
-  SendTransactionBundlrProps,
-  SendTransactionWarpProps,
-  SignTransactionBundlrProps,
-  SignTransactionWarpProps,
-  useOthentReturnProps,
-  verifyArweaveDataProps,
-  verifyBundlrDataProps
-} from "othent";
+import * as othent from "@othent/kms";
+
+import { userDetails } from "./utils";
+import { ConnectResult } from "./types";
 
 export default class OthentStrategy implements Strategy {
   public id: "othent" = "othent";
@@ -27,9 +16,7 @@ export default class OthentStrategy implements Strategy {
   public logo = "33nBIUNlGK4MnWtJZQy9EzkVJaAd7WoydIKfkJoMvDs";
   public url = "https://othent.io";
 
-  #apiID = "e923634af8cc8b63bc8c74735d177aae";
   #addressListeners: ListenerFunction[] = [];
-  #othent: useOthentReturnProps | undefined;
   #currentAddress: string = "";
 
   constructor() {}
@@ -38,41 +25,11 @@ export default class OthentStrategy implements Strategy {
    * Advanced function to override the default API ID
    * Othent uses.
    */
-  public __overrideApiID(othentApiID: string) {
-    this.#apiID = othentApiID;
-  }
-
-  async #othentInstance(ensureConnection = true) {
-    if (this.#othent && !ensureConnection) {
-      return this.#othent;
-    }
-
-    if (!this.#othent) {
-      try {
-        // init othent
-        this.#othent = await Othent({
-          API_ID: this.#apiID
-        });
-      } catch (error: any) {
-        throw new Error(`[Arweave Wallet Kit] ${error.message ?? error}`);
-      }
-    }
-
-    if (ensureConnection) {
-      const permissions = await this.getPermissions();
-
-      if (permissions.length === 0) {
-        throw new Error("[Arweave Wallet Kit] You are not connected to Othent");
-      }
-    }
-
-    return this.#othent;
-  }
 
   public async isAvailable() {
     try {
       // ensure instance
-      await this.#othentInstance(false);
+      // await this.#othentInstance(false);
 
       return true;
     } catch {
@@ -81,30 +38,22 @@ export default class OthentStrategy implements Strategy {
   }
 
   public async ping() {
-    const othent = await this.#othentInstance(false);
-
-    return await othent.ping();
+    // const othent = await this.#othentInstance(false);
+    // return await othent.ping();
   }
 
-  public async connect(
-    permissions: PermissionType[],
-    appInfo?: AppInfo,
-    gateway?: GatewayConfig
-  ) {
-    const othent = await this.#othentInstance(false);
-    const res = await othent.logIn({ testNet: false });
+  public async connect() {
+    const user = (await othent.connect()) as ConnectResult;
 
     for (const listener of this.#addressListeners) {
-      listener(res.contract_id);
+      listener(user.walletAddress);
     }
 
-    this.#currentAddress = res.contract_id;
+    this.#currentAddress = user.walletAddress;
   }
 
   public async disconnect() {
-    const othent = await this.#othentInstance();
-
-    await othent.logOut();
+    await othent.disconnect();
 
     for (const listener of this.#addressListeners) {
       listener(undefined as any);
@@ -113,16 +62,38 @@ export default class OthentStrategy implements Strategy {
     this.#currentAddress = "";
   }
 
+  public async decrypt(
+    data: BufferSource,
+    algorithm: RsaOaepParams | AesCtrParams | AesCbcParams | AesGcmParams
+  ): Promise<Uint8Array> {
+    //
+
+    // return []
+    return "" as any;
+  }
+
+  public async dispatch(transaction: Transaction): Promise<DispatchResult> {
+    return "" as any;
+  }
+
+  public async encrypt(
+    data: BufferSource,
+    algorithm: RsaOaepParams | AesCtrParams | AesCbcParams | AesGcmParams
+  ): Promise<Uint8Array> {
+    //
+
+    // return []
+    return "" as any;
+  }
+
   public async getPermissions() {
-    const othent = await this.#othentInstance(false);
-
     try {
-      const res = await othent.userDetails();
+      const res = await userDetails();
 
-      if (res.contract_id !== this.#currentAddress) {
-        this.#currentAddress = res.contract_id;
+      if (res.walletAddress !== this.#currentAddress) {
+        this.#currentAddress = res.walletAddress;
         for (const listener of this.#addressListeners) {
-          listener(res.contract_id);
+          listener(res.walletAddress);
         }
       }
 
@@ -143,22 +114,35 @@ export default class OthentStrategy implements Strategy {
   }
 
   public async getActiveAddress(): Promise<string> {
-    const othent = await this.#othentInstance(false);
-    const res = await othent.userDetails();
+    const address = await othent.getActiveKey();
 
-    return res.contract_id;
+    return address;
   }
 
   public async getAllAddresses(): Promise<string[]> {
-    const addr = await this.getActiveAddress();
+    const addr = await othent.getActiveKey();
 
     return [addr];
   }
 
-  /**
-   * Same as "sendTransactionArweave()" of the Othent SDK
-   */
-  // @ts-expect-error - Return type is different for Othent transaction signing
+  public async getActivePublicKey(): Promise<string> {
+    const pubKey = await othent.getActivePublicKey();
+
+    return pubKey;
+  }
+
+  public async getArweaveConfig(): Promise<GatewayConfig> {
+    return "" as any;
+  }
+
+  public async getWalletNames(): Promise<{
+    [addr: string]: string;
+  }> {
+    const addr = await othent.getWalletNames();
+
+    return { addr };
+  }
+
   public async sign(transaction: Transaction, options?: SignatureOptions) {
     if (options) {
       console.warn(
@@ -166,132 +150,23 @@ export default class OthentStrategy implements Strategy {
       );
     }
 
+    if (!this.#currentAddress) {
+      throw new Error("You need to be loggedin before signing a transaction");
+    }
+
     if (transaction.quantity !== "0" && transaction.target !== "") {
       throw new Error(
         "[Arweave Wallet Kit] Signing with Othent only supports data type transactions"
       );
     }
-    const othent = await this.#othentInstance(false);
 
-    const signedTransaction = await othent.signTransactionArweave({
-      othentFunction: "uploadData",
-      data: transaction.data,
-      tags: decodeTags(transaction.tags)
-    });
+    const signedTransaction = await othent.sign(transaction);
 
     return signedTransaction;
   }
 
-  public async signTransactionBundlr(params: SignTransactionBundlrProps) {
-    const othent = await this.#othentInstance();
-
-    return await othent.signTransactionBundlr(params);
-  }
-
-  public async signTransactionWarp(params: SignTransactionWarpProps) {
-    const othent = await this.#othentInstance();
-
-    return await othent.signTransactionWarp(params);
-  }
-
-  public async sendTransactionArweave(params: SendTransactionArweaveProps) {
-    const othent = await this.#othentInstance();
-
-    return await othent.sendTransactionArweave(params);
-  }
-
-  public async sendTransactionBundlr(params: SendTransactionBundlrProps) {
-    const othent = await this.#othentInstance();
-
-    return await othent.sendTransactionBundlr(params);
-  }
-
-  public async sendTransactionWarp(params: SendTransactionWarpProps) {
-    const othent = await this.#othentInstance();
-
-    return await othent.sendTransactionWarp(params);
-  }
-
-  public async verifyArweaveData(params: verifyArweaveDataProps) {
-    const othent = await this.#othentInstance();
-
-    return await othent.verifyArweaveData(params);
-  }
-
-  public async verifyBundlrData(params: verifyBundlrDataProps) {
-    const othent = await this.#othentInstance();
-
-    return await othent.verifyBundlrData(params);
-  }
-
-  public async dispatch(transaction: Transaction): Promise<DispatchResult> {
-    try {
-      const othent = await this.#othentInstance(false);
-
-      const tags = decodeTags(transaction.tags);
-
-      const signedTransaction = await othent.signTransactionBundlr({
-        othentFunction: "uploadData",
-        data: transaction.data,
-        tags
-      });
-
-      const res = await othent.sendTransactionBundlr(signedTransaction);
-
-      if (res.success === true) {
-        return { id: res.transactionId, type: "BUNDLED" };
-      } else {
-        try {
-          const othent = await this.#othentInstance(false);
-
-          const signedTransaction = await othent.signTransactionArweave({
-            othentFunction: "uploadData",
-            data: transaction.data,
-            tags
-          });
-
-          const res = await othent.sendTransactionArweave(signedTransaction);
-
-          if (res.success === true) {
-            return { id: res.transactionId, type: "BASE" };
-          } else {
-            throw new Error(
-              `Failed to dispatch layer transaction. Please recheck request.`
-            );
-          }
-        } catch (error) {
-          throw new Error(
-            `Unable to dispatch Base layer transaction: ${error}`
-          );
-        }
-      }
-    } catch (error) {
-      throw new Error(`Unable to dispatch Bundled transaction: ${error}`);
-    }
-  }
-
-  public async queryWalletAddressTxns(params: queryWalletAddressTxnsProps) {
-    const othent = await this.#othentInstance();
-
-    return await othent.queryWalletAddressTxns(params);
-  }
-
   public async userDetails() {
-    const othent = await this.#othentInstance();
-
-    return await othent.userDetails();
-  }
-
-  public async readContract() {
-    const othent = await this.#othentInstance();
-
-    return await othent.readContract();
-  }
-
-  public async readCustomContract(params: readCustomContractProps) {
-    const othent = await this.#othentInstance();
-
-    return await othent.readCustomContract(params);
+    return await userDetails();
   }
 
   public addAddressEvent(listener: ListenerFunction) {
@@ -308,6 +183,13 @@ export default class OthentStrategy implements Strategy {
       this.#addressListeners.indexOf(listener as any),
       1
     );
+  }
+
+  public async signature(
+    data: Uint8Array,
+    algorithm: AlgorithmIdentifier | RsaPssParams | EcdsaParams
+  ): Promise<Uint8Array> {
+    return "" as any;
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,1 +1,28 @@
+import { ConnectReturnType } from "@othent/kms";
+
 export type ListenerFunction = (address: string) => void;
+export interface ConnectResult extends ConnectReturnType {
+  walletAddress: string;
+}
+
+export interface DecodedJWT {
+  walletAddress: string;
+  owner: string;
+  given_name: string;
+  family_name: string;
+  nickname: string;
+  name: string;
+  picture: string;
+  locale: string;
+  updated_at?: string;
+  email: string;
+  email_verified: string;
+  sub: string;
+  iss?: string;
+  aud?: string;
+  iat?: number;
+  exp?: number;
+  sid?: string;
+  nonce?: string;
+  data?: any;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -46,6 +46,5 @@ export function deleteStoredToken() {
   if (!id_token) {
     return true;
   }
-
   localStorage.removeItem("id_token");
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -36,6 +36,16 @@ export async function userDetails(): Promise<ConnectResult> {
   delete decoded_JWT.iat;
   delete decoded_JWT.exp;
   delete decoded_JWT.updated_at;
-  
+
   return decoded_JWT;
+}
+
+export function deleteStoredToken() {
+  const id_token = localStorage.getItem("id_token");
+
+  if (!id_token) {
+    return true;
+  }
+
+  localStorage.removeItem("id_token");
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,7 @@
 import { type Tag } from "arweave/web/lib/transaction";
+import { jwtDecode } from "jwt-decode";
+
+import { ConnectResult, DecodedJWT } from "./types";
 
 /**
  * Decode an array of tags
@@ -16,4 +19,23 @@ export function decodeTags(tags: Tag[]) {
       return tag;
     }
   });
+}
+
+export async function userDetails(): Promise<ConnectResult> {
+  const id_token = localStorage.getItem("id_token");
+
+  if (!id_token) {
+    throw new Error("Error retrieving session id_token.");
+  }
+
+  const decoded_JWT: DecodedJWT = jwtDecode(id_token);
+  delete decoded_JWT.nonce;
+  delete decoded_JWT.sid;
+  delete decoded_JWT.aud;
+  delete decoded_JWT.iss;
+  delete decoded_JWT.iat;
+  delete decoded_JWT.exp;
+  delete decoded_JWT.updated_at;
+  
+  return decoded_JWT;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -28,7 +28,7 @@ export async function userDetails(): Promise<ConnectResult> {
     throw new Error("Error retrieving session id_token.");
   }
 
-  const decoded_JWT: DecodedJWT = jwtDecode(id_token);
+  const decoded_JWT: ConnectResult = jwtDecode(id_token);
   delete decoded_JWT.nonce;
   delete decoded_JWT.sid;
   delete decoded_JWT.aud;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -48,3 +48,9 @@ export function deleteStoredToken() {
   }
   localStorage.removeItem("id_token");
 }
+
+export function isBase64(str: string) {
+  const base64Regex = /^[A-Za-z0-9+/]*={0,2}$/;
+
+  return base64Regex.test(str);
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
       fileName: (format) => `index.${format}.js`
     },
     rollupOptions: {
-      external: ["othent", "@arweave-wallet-kit/core"]
+      external: ["@arweave-wallet-kit/core"]
     }
   }
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@arweave-wallet-kit/core@^0.0.1-beta.1":
-  version "0.0.1-beta.1"
-  resolved "https://registry.yarnpkg.com/@arweave-wallet-kit/core/-/core-0.0.1-beta.1.tgz#2df72e5580fb2f108ffaa4d5f2f89074a926c539"
-  integrity sha512-R40s5n4yMvcUyI/ZBzOKnJpoxt+V3K05rT7MU/jm4AcqLEj/m2X6rU10nbH/PwYveyK8rHKJTlH+q+YpCbGn3w==
+"@arweave-wallet-kit/core@^0.0.1-beta.5":
+  version "0.0.1-beta.5"
+  resolved "https://registry.yarnpkg.com/@arweave-wallet-kit/core/-/core-0.0.1-beta.5.tgz#08594f53ea1ced64efe052e289f0775fc73095c9"
+  integrity sha512-lEMtg+wyUjyQC6eXljW6T7wH5DnqLPoa7x3RZ/1aEUV5CuAgIxqIH2j2Naq5ONfDZMd6yiZVAu348KcXtgZYXQ==
 
 "@auth0/auth0-spa-js@^2.0.4":
   version "2.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -132,17 +132,6 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.18.12.tgz#1da26735ce5954bf914f8f2117b5096c548bbba2"
   integrity sha512-O0UYQVkvfM/jO8a4OwoV0mAKSJw+mjWTAd1MJd/1FCX6uiMdLmMRPK/w6e9OQ0ob2WGxzIm9va/KG0Ja4zIOgg==
 
-"@irys/arweave@^0.0.2":
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/@irys/arweave/-/arweave-0.0.2.tgz#c0e73eb8c15e323342d33ea92701d4036fd22ae3"
-  integrity sha512-ddE5h4qXbl0xfGlxrtBIwzflaxZUDlDs43TuT0u1OMfyobHul4AA1VEX72Rpzw2bOh4vzoytSqA1jCM7x9YtHg==
-  dependencies:
-    asn1.js "^5.4.1"
-    async-retry "^1.3.3"
-    axios "^1.4.0"
-    base64-js "^1.5.1"
-    bignumber.js "^9.1.1"
-
 "@microsoft/api-extractor-model@7.27.4":
   version "7.27.4"
   resolved "https://registry.yarnpkg.com/@microsoft/api-extractor-model/-/api-extractor-model-7.27.4.tgz#ddc566ead99737c1032d692829edd954870f7d35"
@@ -185,13 +174,13 @@
   resolved "https://registry.yarnpkg.com/@microsoft/tsdoc/-/tsdoc-0.14.2.tgz#c3ec604a0b54b9a9b87e9735dfc59e1a5da6a5fb"
   integrity sha512-9b8mPpKrfeGRuhFH5iO1iwCLeIIsV6+H1sRfxbkoGXIyQE2BTsPd9zqSqQJ+pv5sJ/hT5M1zvOFL02MnEezFug==
 
-"@othent/kms@^1.0.6":
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/@othent/kms/-/kms-1.0.6.tgz#c63e65350ab84e889b2583a6ae5fce1330a9a779"
-  integrity sha512-Qfv/zOAdY0LQM0GCfZQ8czgKGfSToJRm8+lrqoGpcpEsVwvPjX1tr659kL/lTeerCE0DNQ7zcF1WTd+y36CtdA==
+"@othent/kms@^1.0.7":
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/@othent/kms/-/kms-1.0.7.tgz#1b7cc4816038db6ca4299efa77264aa54c490455"
+  integrity sha512-k9EyAL5QJ7l2iXJS20Ccck9SukHawFtjSmDAzhih0f2vJl430dseIUEEy8awhtIhBv48FsP2wxKYEGrzaW2PAw==
   dependencies:
     "@auth0/auth0-spa-js" "^2.1.2"
-    "@irys/arweave" "^0.0.2"
+    Buffer "^0.0.0"
     arweave "^1.14.4"
     axios "^1.6.0"
     base64-js "^1.5.1"
@@ -330,6 +319,11 @@
     "@volar/typescript" "~1.8.0"
     "@vue/language-core" "1.8.4"
 
+Buffer@^0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/Buffer/-/Buffer-0.0.0.tgz#82cf8e986a2109ff6d1d6f1c436e47d07127aea4"
+  integrity sha512-+zdncl8lI5TCkARStn9F1BwcuJYofYmD0oEHe5FNfCvGfeDJwf6+dSikCdQN6BMXXmHMhNNUagBN367WST1AIQ==
+
 ajv@~6.12.6:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
@@ -384,13 +378,6 @@ asn1.js@^5.0.1, asn1.js@^5.3.0, asn1.js@^5.4.1:
     minimalistic-assert "^1.0.0"
     safer-buffer "^2.1.0"
 
-async-retry@^1.3.3:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/async-retry/-/async-retry-1.3.3.tgz#0e7f36c04d8478e7a58bdbed80cedf977785f280"
-  integrity sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==
-  dependencies:
-    retry "0.13.1"
-
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
@@ -405,7 +392,7 @@ axios@^1.3.4:
     form-data "^4.0.0"
     proxy-from-env "^1.1.0"
 
-axios@^1.4.0, axios@^1.6.0:
+axios@^1.6.0:
   version "1.6.5"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.5.tgz#2c090da14aeeab3770ad30c3a1461bc970fb0cd8"
   integrity sha512-Ii012v05KEVuUoFWmMW/UQv9aRIc3ZwkWDcM+h5Il8izZCtRVpDUfwpoFf7eOtajT3QiGR4yDUx7lPqHJULgbg==
@@ -433,11 +420,6 @@ bignumber.js@^9.0.2:
   version "9.1.1"
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.1.1.tgz#c4df7dc496bd849d4c9464344c1aa74228b4dac6"
   integrity sha512-pHm4LsMJ6lzgNGVfZHjMoO8sdoRhOzOH4MLmY65Jg70bpxCKu5iOHNJyfF6OyvYw7t8Fpf35RuzUyqnQsj8Vig==
-
-bignumber.js@^9.1.1:
-  version "9.1.2"
-  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.1.2.tgz#b7c4242259c008903b13707983b5f4bbd31eda0c"
-  integrity sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==
 
 bn.js@^4.0.0, bn.js@^4.11.9:
   version "4.12.0"
@@ -903,11 +885,6 @@ resolve@~1.22.1:
     is-core-module "^2.11.0"
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
-
-retry@0.13.1:
-  version "0.13.1"
-  resolved "https://registry.yarnpkg.com/retry/-/retry-0.13.1.tgz#185b1587acf67919d63b357349e03537b2484658"
-  integrity sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==
 
 rimraf@^3.0.0:
   version "3.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -132,6 +132,17 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.18.12.tgz#1da26735ce5954bf914f8f2117b5096c548bbba2"
   integrity sha512-O0UYQVkvfM/jO8a4OwoV0mAKSJw+mjWTAd1MJd/1FCX6uiMdLmMRPK/w6e9OQ0ob2WGxzIm9va/KG0Ja4zIOgg==
 
+"@irys/arweave@^0.0.2":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/@irys/arweave/-/arweave-0.0.2.tgz#c0e73eb8c15e323342d33ea92701d4036fd22ae3"
+  integrity sha512-ddE5h4qXbl0xfGlxrtBIwzflaxZUDlDs43TuT0u1OMfyobHul4AA1VEX72Rpzw2bOh4vzoytSqA1jCM7x9YtHg==
+  dependencies:
+    asn1.js "^5.4.1"
+    async-retry "^1.3.3"
+    axios "^1.4.0"
+    base64-js "^1.5.1"
+    bignumber.js "^9.1.1"
+
 "@microsoft/api-extractor-model@7.27.4":
   version "7.27.4"
   resolved "https://registry.yarnpkg.com/@microsoft/api-extractor-model/-/api-extractor-model-7.27.4.tgz#ddc566ead99737c1032d692829edd954870f7d35"
@@ -174,18 +185,22 @@
   resolved "https://registry.yarnpkg.com/@microsoft/tsdoc/-/tsdoc-0.14.2.tgz#c3ec604a0b54b9a9b87e9735dfc59e1a5da6a5fb"
   integrity sha512-9b8mPpKrfeGRuhFH5iO1iwCLeIIsV6+H1sRfxbkoGXIyQE2BTsPd9zqSqQJ+pv5sJ/hT5M1zvOFL02MnEezFug==
 
-"@othent/kms@^1.0.5":
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/@othent/kms/-/kms-1.0.5.tgz#44d69c62b5b935707c5bd2ec69c672693839a873"
-  integrity sha512-rsik9JMEcCpc2a5vP9Htb5kacUxt2p3IqR0qGOE2TxJa/i7iPDc4A3ftGk+yHgYrdR0gPGI3UPJ7Xjur1JZTCA==
+"@othent/kms@^1.0.6":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@othent/kms/-/kms-1.0.6.tgz#c63e65350ab84e889b2583a6ae5fce1330a9a779"
+  integrity sha512-Qfv/zOAdY0LQM0GCfZQ8czgKGfSToJRm8+lrqoGpcpEsVwvPjX1tr659kL/lTeerCE0DNQ7zcF1WTd+y36CtdA==
   dependencies:
     "@auth0/auth0-spa-js" "^2.1.2"
+    "@irys/arweave" "^0.0.2"
+    arweave "^1.14.4"
     axios "^1.6.0"
     base64-js "^1.5.1"
+    base64url "^3.0.1"
     buffer "^6.0.3"
     jwk-to-pem "^2.0.5"
     jwt-decode "^4.0.0"
     pem-jwk "^2.0.0"
+    tmp-promise "^3.0.3"
 
 "@rollup/pluginutils@^5.0.2":
   version "5.0.2"
@@ -349,7 +364,7 @@ arweave@^1.10.13:
     base64-js "^1.5.1"
     bignumber.js "^9.0.2"
 
-arweave@^1.12.2:
+arweave@^1.12.2, arweave@^1.14.4:
   version "1.14.4"
   resolved "https://registry.yarnpkg.com/arweave/-/arweave-1.14.4.tgz#5ba22136aa0e7fd9495258a3931fb770c9d6bf21"
   integrity sha512-tmqU9fug8XAmFETYwgUhLaD3WKav5DaM4p1vgJpEj/Px2ORPPMikwnSySlFymmL2qgRh2ZBcZsg11+RXPPGLsA==
@@ -369,6 +384,13 @@ asn1.js@^5.0.1, asn1.js@^5.3.0, asn1.js@^5.4.1:
     minimalistic-assert "^1.0.0"
     safer-buffer "^2.1.0"
 
+async-retry@^1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/async-retry/-/async-retry-1.3.3.tgz#0e7f36c04d8478e7a58bdbed80cedf977785f280"
+  integrity sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==
+  dependencies:
+    retry "0.13.1"
+
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
@@ -383,7 +405,7 @@ axios@^1.3.4:
     form-data "^4.0.0"
     proxy-from-env "^1.1.0"
 
-axios@^1.6.0:
+axios@^1.4.0, axios@^1.6.0:
   version "1.6.5"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.5.tgz#2c090da14aeeab3770ad30c3a1461bc970fb0cd8"
   integrity sha512-Ii012v05KEVuUoFWmMW/UQv9aRIc3ZwkWDcM+h5Il8izZCtRVpDUfwpoFf7eOtajT3QiGR4yDUx7lPqHJULgbg==
@@ -402,15 +424,33 @@ base64-js@^1.3.1, base64-js@^1.5.1:
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
 
+base64url@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/base64url/-/base64url-3.0.1.tgz#6399d572e2bc3f90a9a8b22d5dbb0a32d33f788d"
+  integrity sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==
+
 bignumber.js@^9.0.2:
   version "9.1.1"
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.1.1.tgz#c4df7dc496bd849d4c9464344c1aa74228b4dac6"
   integrity sha512-pHm4LsMJ6lzgNGVfZHjMoO8sdoRhOzOH4MLmY65Jg70bpxCKu5iOHNJyfF6OyvYw7t8Fpf35RuzUyqnQsj8Vig==
 
+bignumber.js@^9.1.1:
+  version "9.1.2"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.1.2.tgz#b7c4242259c008903b13707983b5f4bbd31eda0c"
+  integrity sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==
+
 bn.js@^4.0.0, bn.js@^4.11.9:
   version "4.12.0"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.12.0.tgz#775b3f278efbb9718eec7361f483fb36fbbfea88"
   integrity sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==
+
+brace-expansion@^1.1.7:
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
+  integrity sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
+  dependencies:
+    balanced-match "^1.0.0"
+    concat-map "0.0.1"
 
 brace-expansion@^2.0.1:
   version "2.0.1"
@@ -448,6 +488,11 @@ commander@^10.0.0:
   version "10.0.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-10.0.1.tgz#881ee46b4f77d1c1dccc5823433aa39b022cbe06"
   integrity sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==
+
+concat-map@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
+  integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
 
 crypto-js@^4.1.1:
   version "4.2.0"
@@ -555,6 +600,11 @@ fs-extra@~7.0.1:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
+fs.realpath@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
+  integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
+
 fsevents@~2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
@@ -564,6 +614,18 @@ function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
+
+glob@^7.1.3:
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
+  integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.1.1"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
 
 graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   version "4.2.11"
@@ -614,7 +676,15 @@ import-lazy@~4.0.0:
   resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-4.0.0.tgz#e8eb627483a0a43da3c03f3e35548be5cb0cc153"
   integrity sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==
 
-inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4:
+inflight@^1.0.4:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
+  integrity sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==
+  dependencies:
+    once "^1.3.0"
+    wrappy "1"
+
+inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -716,6 +786,13 @@ minimalistic-crypto-utils@^1.0.1:
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
   integrity sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==
 
+minimatch@^3.1.1:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
+  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
+  dependencies:
+    brace-expansion "^1.1.7"
+
 minimatch@^9.0.0:
   version "9.0.3"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.3.tgz#a6e00c3de44c3a542bfaae70abfc22420a6da825"
@@ -738,6 +815,13 @@ nanoid@^3.3.6:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.6.tgz#443380c856d6e9f9824267d960b4236ad583ea4c"
   integrity sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==
 
+once@^1.3.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
+  integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
+  dependencies:
+    wrappy "1"
+
 othent@^1.0.645:
   version "1.0.646"
   resolved "https://registry.yarnpkg.com/othent/-/othent-1.0.646.tgz#a8f5e7248205c2319e74f18d73a83841da4049a1"
@@ -751,6 +835,11 @@ othent@^1.0.645:
     jwk-to-pem "^2.0.5"
     jwt-decode "^3.1.2"
     supports-color "^8.1.1"
+
+path-is-absolute@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
+  integrity sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==
 
 path-parse@^1.0.6, path-parse@^1.0.7:
   version "1.0.7"
@@ -814,6 +903,18 @@ resolve@~1.22.1:
     is-core-module "^2.11.0"
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
+
+retry@0.13.1:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/retry/-/retry-0.13.1.tgz#185b1587acf67919d63b357349e03537b2484658"
+  integrity sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==
+
+rimraf@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
+  dependencies:
+    glob "^7.1.3"
 
 rollup@*, rollup@^3.25.2:
   version "3.26.2"
@@ -882,6 +983,20 @@ supports-preserve-symlinks-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
+
+tmp-promise@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/tmp-promise/-/tmp-promise-3.0.3.tgz#60a1a1cc98c988674fcbfd23b6e3367bdeac4ce7"
+  integrity sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==
+  dependencies:
+    tmp "^0.2.0"
+
+tmp@^0.2.0:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.1.tgz#8457fc3037dcf4719c251367a1af6500ee1ccf14"
+  integrity sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==
+  dependencies:
+    rimraf "^3.0.0"
 
 typescript@^5.1.6:
   version "5.1.6"
@@ -953,6 +1068,11 @@ vue-tsc@^1.8.1:
     "@vue/language-core" "1.8.4"
     "@vue/typescript" "1.8.4"
     semver "^7.3.8"
+
+wrappy@1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
+  integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
 yallist@^4.0.0:
   version "4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,6 +12,11 @@
   resolved "https://registry.yarnpkg.com/@auth0/auth0-spa-js/-/auth0-spa-js-2.1.0.tgz#f1515d5e7d6b6bebe2a035b7297f936e8711f80f"
   integrity sha512-7cF2NxrslgjArIdBwpNg02atPldpHHOrXxDScL71cbxKuKny3eziZIpNHQAdsPFiLhjKQ+izWmLq2ZRFlYB/eQ==
 
+"@auth0/auth0-spa-js@^2.1.2":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@auth0/auth0-spa-js/-/auth0-spa-js-2.1.3.tgz#aabf6f439e41edbeef0cf4766ad754e5b47616e5"
+  integrity sha512-NMTBNuuG4g3rame1aCnNS5qFYIzsTUV5qTFPRfTyYFS1feS6jsCBR+eTq9YkxCp1yuoM2UIcjunPaoPl77U9xQ==
+
 "@babel/parser@^7.21.3":
   version "7.22.7"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.22.7.tgz#df8cf085ce92ddbdbf668a7f186ce848c9036cae"
@@ -169,6 +174,19 @@
   resolved "https://registry.yarnpkg.com/@microsoft/tsdoc/-/tsdoc-0.14.2.tgz#c3ec604a0b54b9a9b87e9735dfc59e1a5da6a5fb"
   integrity sha512-9b8mPpKrfeGRuhFH5iO1iwCLeIIsV6+H1sRfxbkoGXIyQE2BTsPd9zqSqQJ+pv5sJ/hT5M1zvOFL02MnEezFug==
 
+"@othent/kms@^1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@othent/kms/-/kms-1.0.5.tgz#44d69c62b5b935707c5bd2ec69c672693839a873"
+  integrity sha512-rsik9JMEcCpc2a5vP9Htb5kacUxt2p3IqR0qGOE2TxJa/i7iPDc4A3ftGk+yHgYrdR0gPGI3UPJ7Xjur1JZTCA==
+  dependencies:
+    "@auth0/auth0-spa-js" "^2.1.2"
+    axios "^1.6.0"
+    base64-js "^1.5.1"
+    buffer "^6.0.3"
+    jwk-to-pem "^2.0.5"
+    jwt-decode "^4.0.0"
+    pem-jwk "^2.0.0"
+
 "@rollup/pluginutils@^5.0.2":
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-5.0.2.tgz#012b8f53c71e4f6f9cb317e311df1404f56e7a33"
@@ -321,7 +339,7 @@ argparse@~1.0.9:
   dependencies:
     sprintf-js "~1.0.2"
 
-arweave@^1.10.13, arweave@^1.14.0:
+arweave@^1.10.13:
   version "1.14.0"
   resolved "https://registry.yarnpkg.com/arweave/-/arweave-1.14.0.tgz#a4424455a4137b7708cdc627b5bda1881d6881b5"
   integrity sha512-P2g9FjbJZQfk0Q3a5R2aCyPP3jen3ZN6Oxh6p6BlwEGHn5M5O0KvZSaiNV4X/PENgnZA4+afOf9MR3ySGcR3JQ==
@@ -331,7 +349,17 @@ arweave@^1.10.13, arweave@^1.14.0:
     base64-js "^1.5.1"
     bignumber.js "^9.0.2"
 
-asn1.js@^5.3.0, asn1.js@^5.4.1:
+arweave@^1.12.2:
+  version "1.14.4"
+  resolved "https://registry.yarnpkg.com/arweave/-/arweave-1.14.4.tgz#5ba22136aa0e7fd9495258a3931fb770c9d6bf21"
+  integrity sha512-tmqU9fug8XAmFETYwgUhLaD3WKav5DaM4p1vgJpEj/Px2ORPPMikwnSySlFymmL2qgRh2ZBcZsg11+RXPPGLsA==
+  dependencies:
+    arconnect "^0.4.2"
+    asn1.js "^5.4.1"
+    base64-js "^1.5.1"
+    bignumber.js "^9.0.2"
+
+asn1.js@^5.0.1, asn1.js@^5.3.0, asn1.js@^5.4.1:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/asn1.js/-/asn1.js-5.4.1.tgz#11a980b84ebb91781ce35b0fdc2ee294e3783f07"
   integrity sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==
@@ -355,12 +383,21 @@ axios@^1.3.4:
     form-data "^4.0.0"
     proxy-from-env "^1.1.0"
 
+axios@^1.6.0:
+  version "1.6.5"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.5.tgz#2c090da14aeeab3770ad30c3a1461bc970fb0cd8"
+  integrity sha512-Ii012v05KEVuUoFWmMW/UQv9aRIc3ZwkWDcM+h5Il8izZCtRVpDUfwpoFf7eOtajT3QiGR4yDUx7lPqHJULgbg==
+  dependencies:
+    follow-redirects "^1.15.4"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
+
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
-base64-js@^1.5.1:
+base64-js@^1.3.1, base64-js@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
@@ -387,6 +424,14 @@ brorand@^1.1.0:
   resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
   integrity sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==
 
+buffer@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-6.0.3.tgz#2ace578459cc8fbe2a70aaa8f52ee63b6a74c6c6"
+  integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.2.1"
+
 colors@~1.2.1:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.2.5.tgz#89c7ad9a374bc030df8013241f68136ed8835afc"
@@ -404,10 +449,10 @@ commander@^10.0.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-10.0.1.tgz#881ee46b4f77d1c1dccc5823433aa39b022cbe06"
   integrity sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==
 
-crypto-hash@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/crypto-hash/-/crypto-hash-2.0.1.tgz#46c3732e65a078ea06b8b4ae686db41216f81213"
-  integrity sha512-t4mkp7Vh6MuCZRBf0XLzBOfhkH3nW6YEAotMDSjshVQ1GffCMGdPLSr7pKH0rdXY02jTjAZ7QW2apD0buaZXcQ==
+crypto-js@^4.1.1:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-4.2.0.tgz#4d931639ecdfd12ff80e8186dba6af2c2e856631"
+  integrity sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==
 
 de-indent@^1.0.2:
   version "1.0.2"
@@ -487,6 +532,11 @@ follow-redirects@^1.15.0:
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
   integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
 
+follow-redirects@^1.15.4:
+  version "1.15.5"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.5.tgz#54d4d6d062c0fa7d9d17feb008461550e3ba8020"
+  integrity sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==
+
 form-data@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
@@ -554,6 +604,11 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
+ieee754@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
+  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
+
 import-lazy@~4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-4.0.0.tgz#e8eb627483a0a43da3c03f3e35548be5cb0cc153"
@@ -606,6 +661,11 @@ jwt-decode@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-3.1.2.tgz#3fb319f3675a2df0c2895c8f5e9fa4b67b04ed59"
   integrity sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==
+
+jwt-decode@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-4.0.0.tgz#2270352425fd413785b2faf11f6e755c5151bd4b"
+  integrity sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==
 
 kolorist@^1.8.0:
   version "1.8.0"
@@ -678,14 +738,14 @@ nanoid@^3.3.6:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.6.tgz#443380c856d6e9f9824267d960b4236ad583ea4c"
   integrity sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==
 
-othent@^1.0.634:
-  version "1.0.635"
-  resolved "https://registry.yarnpkg.com/othent/-/othent-1.0.635.tgz#4f1aa1577315c37a72123395104667811dac3d44"
-  integrity sha512-ppwpsvd1Jm/ur09LohnQlmeI5JVKSAOlAoTUKAypWa5fPSvawX1mjsbntB94qOSpeOd464Jr08e43MogunIqaQ==
+othent@^1.0.645:
+  version "1.0.646"
+  resolved "https://registry.yarnpkg.com/othent/-/othent-1.0.646.tgz#a8f5e7248205c2319e74f18d73a83841da4049a1"
+  integrity sha512-vb32xTT1DjWv7AVUwYWIjtzfA2HXNE/WAnvO/h/hkQECtrMT+FYee0RnKuk19UuM7kCl0aw3f9Dm/tYZox99mg==
   dependencies:
     "@auth0/auth0-spa-js" "^2.0.4"
     axios "^1.3.4"
-    crypto-hash "^2.0.1"
+    crypto-js "^4.1.1"
     debug "^4.3.4"
     jsrsasign "^10.8.6"
     jwk-to-pem "^2.0.5"
@@ -696,6 +756,13 @@ path-parse@^1.0.6, path-parse@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
+
+pem-jwk@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/pem-jwk/-/pem-jwk-2.0.0.tgz#1c5bb264612fc391340907f5c1de60c06d22f085"
+  integrity sha512-rFxu7rVoHgQ5H9YsP50dDWf0rHjreVA2z0yPiWr5WdH/UHb29hKtF7h6l8vNd1cbYR1t0QL+JKhW55a2ZV4KtA==
+  dependencies:
+    asn1.js "^5.0.1"
 
 picocolors@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Summary
Since othent moved to a new package that includes 2.0 changes, we needed to update OthentStrategy class to work with this new kms sdk. This PR implements necessary logic using latest othent package.

depends on: [#PR](https://github.com/labscommunity/wallet-kit-core/pull/1) [#PR](https://github.com/Othent/KeyManagementService/pull/7) 